### PR TITLE
needed to take .movieData out of the API shaping. Apparently the regu…

### DIFF
--- a/server.js
+++ b/server.js
@@ -73,7 +73,7 @@ async function handleMovies(request, response) {
   try {
     let movieTime = await axios.get(movieURL);
 
-    let groovyMovies = movieTime.data.movieData.results.map(singleFilm => {
+    let groovyMovies = movieTime.data.results.map(singleFilm => {
       return new Film(singleFilm);
     });
     console.log(groovyMovies);


### PR DESCRIPTION
…lar.data.resultsfolder.map was sufficient without needing the api referenced .movieData before the .results. All in the server.js file.